### PR TITLE
Event registrations (API)

### DIFF
--- a/app/controllers/concerns/json_api_controller.rb
+++ b/app/controllers/concerns/json_api_controller.rb
@@ -391,7 +391,7 @@ module JsonApiController
   #   allow_create
   # end
   #
-  def allow_create(controller_attributes: nil)
+  def allow_create(controller_attributes = nil)
     hash = strong_attributes
            .merge(strong_relationships)
            .merge(controller_attributes)

--- a/app/controllers/v1/admin/event_attendees_controller.rb
+++ b/app/controllers/v1/admin/event_attendees_controller.rb
@@ -1,0 +1,35 @@
+module V1
+  module Admin
+    class EventAttendeesController < ApplicationController
+      def index
+        allow_index
+      end
+
+      def show
+        allow_show
+      end
+
+      def create
+        forbidden
+      end
+
+      def update
+        forbidden
+      end
+
+      def destroy
+        forbidden
+      end
+
+      private
+
+      def model_class
+        EventAttendee
+      end
+
+      def serializer_class
+        V1::Admin::EventAttendeeSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/v1/admin/events_controller.rb
+++ b/app/controllers/v1/admin/events_controller.rb
@@ -39,6 +39,14 @@ module V1
           start_date
           end_date
           description
+          has_registration_form
+          ask_first_name
+          ask_last_name
+          ask_role
+          ask_company
+          confirmation_email_subject
+          confirmation_email_body
+          confirmation_email_bcc
         ]
       end
 
@@ -51,6 +59,8 @@ module V1
       def permitted_includes
         %i[
           country
+          permalinks
+          event_attendees
         ]
       end
     end

--- a/app/controllers/v1/admin/permalinks_controller.rb
+++ b/app/controllers/v1/admin/permalinks_controller.rb
@@ -10,7 +10,11 @@ module V1
       end
 
       def create
-        allow_create
+        allow_create(
+          {
+            slug: unique_slug
+          }
+        )
       end
 
       def update
@@ -39,10 +43,34 @@ module V1
         ]
       end
 
+      def creatable_relationships
+        %i[
+          event
+        ]
+      end
+
       def permitted_filters
         %i[
           slug
         ]
+      end
+
+      def unique_slug
+        slug = nil
+        unique = false
+
+        until slug.present? && unique
+          slug = three_random_letters
+          record = Permalink.find_by slug: slug
+          unique = record.nil?
+        end
+
+        slug
+      end
+
+      def three_random_letters
+        charset = Array('A'..'Z') + Array('a'..'z')
+        Array.new(3) { charset.sample }.join
       end
     end
   end

--- a/app/controllers/v1/public/event_attendees_controller.rb
+++ b/app/controllers/v1/public/event_attendees_controller.rb
@@ -1,0 +1,51 @@
+module V1
+  module Public
+    class EventAttendeesController < ApplicationController
+      def index
+        forbidden
+      end
+
+      def show
+        forbidden
+      end
+
+      def create
+        allow_create
+      end
+
+      def update
+        allow_update
+      end
+
+      def destroy
+        forbidden
+      end
+
+      private
+
+      def model_class
+        EventAttendee
+      end
+
+      def serializer_class
+        V1::Public::EventAttendeeSerializer
+      end
+
+      def creatable_attributes
+        %i[
+          first_name
+          last_name
+          role
+          company
+          email
+        ]
+      end
+
+      def creatable_relationships
+        %i[
+          event
+        ]
+      end
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,17 +2,30 @@
 #
 # Table name: events
 #
-#  id          :uuid             not null, primary key
-#  city        :string
-#  dates       :string
-#  description :string
-#  end_date    :string
-#  name        :string
-#  start_date  :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  country_id  :string
+#  id                         :uuid             not null, primary key
+#  ask_company                :boolean
+#  ask_first_name             :boolean
+#  ask_last_name              :boolean
+#  ask_role                   :boolean
+#  city                       :string
+#  confirmation_email_bcc     :string           default("s.teliszewski@interflux.com, jw@interflux.au")
+#  confirmation_email_body    :string           default("Hello {first_name} {last_name},    We look forward seeing you at {event_name} on {event_date} in {event_location}.    Best regards,    The Interflux Electronics team")
+#  confirmation_email_subject :string           default("See you soon at {event_name}!")
+#  dates                      :string
+#  description                :string
+#  end_date                   :string
+#  has_registration_form      :boolean
+#  name                       :string
+#  start_date                 :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  country_id                 :string
 #
 class Event < ApplicationRecord
   belongs_to :country
+
+  has_many :permalinks
+  has_many :event_attendees
+
+  alias_attribute :attendees, :event_attendees
 end

--- a/app/models/event_attendee.rb
+++ b/app/models/event_attendee.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: event_attendees
+#
+#  id         :uuid             not null, primary key
+#  company    :string
+#  email      :string
+#  first_name :string
+#  last_name  :string
+#  role       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :uuid
+#  person_id  :uuid
+#
+class EventAttendee < ApplicationRecord
+  belongs_to :event
+  belongs_to :person, optional: true
+end

--- a/app/models/permalink.rb
+++ b/app/models/permalink.rb
@@ -6,9 +6,14 @@
 #  notes       :string
 #  redirect_to :string
 #  slug        :string
+#  event_id    :uuid
+#
+# Indexes
+#
+#  index_permalinks_on_slug  (slug) UNIQUE
 #
 class Permalink < ApplicationRecord
-  # attr :redirect_from
-  # attr :redirect_to
-  # attr :notes
+  belongs_to :event, optional: true
+
+  validates :slug, presence: true, uniqueness: true
 end

--- a/app/serializers/v1/admin/event_attendee_serializer.rb
+++ b/app/serializers/v1/admin/event_attendee_serializer.rb
@@ -1,0 +1,14 @@
+module V1
+  module Admin
+    class EventAttendeeSerializer < ApplicationSerializer
+      attributes :first_name,
+                 :last_name,
+                 :role,
+                 :company,
+                 :email
+
+      belongs_to :event
+      belongs_to :person
+    end
+  end
+end

--- a/app/serializers/v1/admin/event_serializer.rb
+++ b/app/serializers/v1/admin/event_serializer.rb
@@ -6,9 +6,20 @@ module V1
                  :dates,
                  :start_date,
                  :end_date,
-                 :description
+                 :description,
+                 :has_registration_form,
+                 :ask_first_name,
+                 :ask_last_name,
+                 :ask_role,
+                 :ask_company,
+                 :confirmation_email_subject,
+                 :confirmation_email_body,
+                 :confirmation_email_bcc
 
       belongs_to :country
+
+      has_many :event_attendees
+      has_many :permalinks
     end
   end
 end

--- a/app/serializers/v1/admin/permalink_serializer.rb
+++ b/app/serializers/v1/admin/permalink_serializer.rb
@@ -4,6 +4,8 @@ module V1
       attributes :slug,
                  :redirect_to,
                  :notes
+
+      belongs_to :event
     end
   end
 end

--- a/app/serializers/v1/public/event_attendee_serializer.rb
+++ b/app/serializers/v1/public/event_attendee_serializer.rb
@@ -1,0 +1,13 @@
+module V1
+  module Public
+    class EventAttendeeSerializer < ApplicationSerializer
+      attributes :first_name,
+                 :last_name,
+                 :role,
+                 :company,
+                 :email
+
+      belongs_to :event
+    end
+  end
+end

--- a/app/serializers/v1/public/event_serializer.rb
+++ b/app/serializers/v1/public/event_serializer.rb
@@ -6,7 +6,12 @@ module V1
                  :dates,
                  :start_date,
                  :end_date,
-                 :description
+                 :description,
+                 :has_registration_form,
+                 :ask_first_name,
+                 :ask_last_name,
+                 :ask_role,
+                 :ask_company
 
       belongs_to :country
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :document_categories, path: '/document-categories'
       resources :documents
       resources :events
+      resources :event_attendees, path: '/event-attendees'
       resources :features
       resources :images
       resources :languages
@@ -69,6 +70,7 @@ Rails.application.routes.draw do
       resources :document_categories, path: '/document-categories'
       resources :documents
       resources :events
+      resources :event_attendees, path: '/event-attendees'
       resources :features
       resources :images
       resources :languages

--- a/db/migrate/20240406020528_create_event_attendees.rb
+++ b/db/migrate/20240406020528_create_event_attendees.rb
@@ -1,0 +1,33 @@
+class CreateEventAttendees < ActiveRecord::Migration[6.1]
+  def change
+    change_table :events, bulk: true do |t|
+      t.column :has_registration_form, :boolean
+
+      t.column :ask_first_name, :boolean
+      t.column :ask_last_name, :boolean
+      t.column :ask_role, :boolean
+      t.column :ask_company, :boolean
+
+      t.column :confirmation_email_subject, :string, default: 'See you soon at {event_name}!'
+      t.column :confirmation_email_body, :string, default: 'Hello {first_name} {last_name},    We look forward seeing you at {event_name} on {event_date} in {event_location}.    Best regards,    The Interflux Electronics team'
+      t.column :confirmation_email_bcc, :string, default: 's.teliszewski@interflux.com, jw@interflux.au'
+    end
+
+    change_table :permalinks, bulk: true do |t|
+      t.column :event_id, :uuid
+    end
+
+    create_table :event_attendees, id: :uuid do |t|
+      t.uuid :event_id
+      t.uuid :person_id
+
+      t.string :first_name
+      t.string :last_name
+      t.string :role
+      t.string :company
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240407010227_add_unique_constraints_to_permalinks.rb
+++ b/db/migrate/20240407010227_add_unique_constraints_to_permalinks.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintsToPermalinks < ActiveRecord::Migration[6.1]
+  def change
+    add_index :permalinks, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_10_021903) do
+ActiveRecord::Schema.define(version: 2024_04_07_010227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -223,6 +223,18 @@ ActiveRecord::Schema.define(version: 2024_02_10_021903) do
     t.index ["person_id"], name: "index_employees_on_person_id"
   end
 
+  create_table "event_attendees", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "event_id"
+    t.uuid "person_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "role"
+    t.string "company"
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "description"
@@ -233,6 +245,14 @@ ActiveRecord::Schema.define(version: 2024_02_10_021903) do
     t.datetime "updated_at", null: false
     t.string "start_date"
     t.string "end_date"
+    t.boolean "has_registration_form"
+    t.boolean "ask_first_name"
+    t.boolean "ask_last_name"
+    t.boolean "ask_role"
+    t.boolean "ask_company"
+    t.string "confirmation_email_subject", default: "See you soon at {event_name}!"
+    t.string "confirmation_email_body", default: "Hello {first_name} {last_name},    We look forward seeing you at {event_name} on {event_date} in {event_location}.    Best regards,    The Interflux Electronics team"
+    t.string "confirmation_email_bcc", default: "s.teliszewski@interflux.com, jw@interflux.au"
   end
 
   create_table "features", primary_key: "slug", id: :string, force: :cascade do |t|
@@ -314,6 +334,8 @@ ActiveRecord::Schema.define(version: 2024_02_10_021903) do
     t.string "slug"
     t.string "redirect_to"
     t.string "notes"
+    t.uuid "event_id"
+    t.index ["slug"], name: "index_permalinks_on_slug", unique: true
   end
 
   create_table "person_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -2,25 +2,22 @@
 #
 # Table name: events
 #
-#  id          :uuid             not null, primary key
-#  city        :string
-#  dates       :string
-#  description :string
-#  end_date    :string
-#  name        :string
-#  start_date  :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  country_id  :string
+#  id                         :uuid             not null, primary key
+#  ask_company                :boolean
+#  ask_first_name             :boolean
+#  ask_last_name              :boolean
+#  ask_role                   :boolean
+#  city                       :string
+#  confirmation_email_bcc     :string           default("s.teliszewski@interflux.com, jw@interflux.au")
+#  confirmation_email_body    :string           default("Hello {first_name} {last_name},    We look forward seeing you at {event_name} on {event_date} in {event_location}.    Best regards,    The Interflux Electronics team")
+#  confirmation_email_subject :string           default("See you soon at {event_name}!")
+#  dates                      :string
+#  description                :string
+#  end_date                   :string
+#  has_registration_form      :boolean
+#  name                       :string
+#  start_date                 :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  country_id                 :string
 #
-# event_fixture_1:
-#   name: Some Name
-#   slug: some-name
-#   public: true
-#   group: other_thing_fixture_1
-# 
-# event_fixture_2:
-#   name: Some Name
-#   slug: some-name
-#   public: true
-#   group: other_thing_fixture_1


### PR DESCRIPTION
This PR:

* Add the migrations, models, routes, controllers and serialisers for `EventAttendees` and forms. 🎈 
* Fixes issue with `def allow_create`. 🐛 
* Generates random slug for permalinks if created without. 🎲  