### PR TITLE
Event registration confirmation emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'aws-sdk-s3'
 # For HTTP requests (native Rails does this terribly...)
 gem 'faraday'
 
+# For printing curl requests after Faraday requests
+gem 'faraday_curl', groups: %i[development]
+
 # For catching N+1 queries
 gem 'bullet', groups: %i[development test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday_curl (0.0.2)
+      faraday (>= 0.9.0)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -226,6 +228,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   faraday
+  faraday_curl
   jsonapi-serializer
   jwt
   listen

--- a/app/controllers/v1/public/event_attendees_controller.rb
+++ b/app/controllers/v1/public/event_attendees_controller.rb
@@ -38,6 +38,7 @@ module V1
           role
           company
           email
+          locale
         ]
       end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'jw@floatplane.dev'
   layout 'mailer'
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  private
+
+  def log
+    Rails.logger
+  end
 end

--- a/app/models/email_attempt.rb
+++ b/app/models/email_attempt.rb
@@ -1,0 +1,100 @@
+# == Schema Information
+#
+# Table name: email_attempts
+#
+#  id                      :uuid             not null, primary key
+#  bcc                     :string
+#  cc                      :string
+#  created_by_type         :string
+#  delivered               :boolean
+#  from                    :string
+#  postmark_stream         :string
+#  postmark_template_alias :string
+#  postmark_template_model :jsonb
+#  provider                :integer
+#  reply_to                :string
+#  response_body           :jsonb
+#  response_status         :integer
+#  to                      :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  created_by_id           :uuid
+#
+# Indexes
+#
+#  index_email_attempts_on_created_by     (created_by_type,created_by_id)
+#  index_email_attempts_on_response_body  (response_body) USING gin
+#
+class EmailAttempt < ApplicationRecord
+  # The record which created this EmailAttempt
+  belongs_to :created_by, polymorphic: true, optional: true
+
+  # The provider which will send the email for us.
+  # Rails cannot send emails. It only delegates them.
+  # enum :provider, { postmark: 0, sendgrid: 1 }, scopes: true
+
+  after_save :send_email
+
+  private
+
+  def blocker
+    return 'no to' if to.nil?
+    return 'no from' if from.nil?
+    return 'no postmark_stream' if postmark_stream.nil?
+    return 'no postmark_template_alias' if postmark_template_alias.nil?
+    return 'no postmark_template_model' if postmark_template_model.nil?
+    return 'model is not a hash' unless postmark_template_model.is_a? Hash
+
+    # Never deliver an email twice
+    # This also allows admins to edit and retry until delivered
+    return 'already delivered' if delivered == true
+
+    nil
+  end
+
+  def send_email
+    log.info "✅ saved EmailAttempt #{id}"
+
+    if blocker.present?
+      log.warn "🔥 #{blocker}"
+      return
+    end
+
+    log.info '✅ sending ...'
+
+    ap from
+    ap to
+    ap postmark_template_alias
+    ap postmark_template_model
+
+    api = Postmark::Api.new(server_token: ENV['POSTMARK_SERVER_TOKEN'])
+
+    response = api.send_email_with_template(
+      message_stream: postmark_stream,
+      template_alias: postmark_template_alias,
+      template_model: postmark_template_model,
+      from: from,
+      to: to,
+      cc: cc,
+      bcc: bcc,
+      reply_to: reply_to
+    )
+
+    if response.status == 200
+      log.info '✅ success'
+    else
+      log.info '❌ fail'
+    end
+
+    ap response.status
+    ap response.body
+
+    self.response_status = response.status
+    self.response_body = JSON.parse(response.body) if response.body.present?
+    self.delivered = response.status == 200
+
+    save!
+
+    log.info '✅ done'
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,4 +28,28 @@ class Event < ApplicationRecord
   has_many :event_attendees
 
   alias_attribute :attendees, :event_attendees
+
+  def location
+    "#{city}, #{country.name_english}"
+  end
+
+  def start_to_end_date
+    return '?' if sd.nil? && ed.nil?
+
+    return sd.strftime('%a %-d %b %Y') if sd.present? && ed.nil?
+
+    return sd.strftime('%a %-d %b %Y') if ed == sd
+
+    return "#{sd.strftime('%a %d')} to #{ed.strftime('%a %-d %b %Y')}" if sd.month == ed.month
+
+    "#{sd.strftime('%a %-d %b %Y')} to #{ed.strftime('%a %-d %b %Y')}"
+  end
+
+  def sd
+    start_date&.to_date
+  end
+
+  def ed
+    end_date&.to_date
+  end
 end

--- a/app/models/event_attendee.rb
+++ b/app/models/event_attendee.rb
@@ -7,6 +7,7 @@
 #  email      :string
 #  first_name :string
 #  last_name  :string
+#  locale     :string
 #  role       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/event_attendee.rb
+++ b/app/models/event_attendee.rb
@@ -1,3 +1,6 @@
+require 'postmark/api'
+require 'ap'
+
 # == Schema Information
 #
 # Table name: event_attendees
@@ -17,4 +20,68 @@
 class EventAttendee < ApplicationRecord
   belongs_to :event
   belongs_to :person, optional: true
+
+  after_save :send_confirmation_emails
+
+  private
+
+  def send_confirmation_emails
+    log.info "✅ EventAttendee #{id} saved"
+
+    return if email.nil?
+
+    # TODO: Prevent this email from being sent upon every save...
+
+    template_locale = locale == 'fr' ? 'fr' : 'en'
+
+    log.info '✅ creating confirmation email'
+
+    EmailAttempt.create!(
+      to: email,
+      from: 'Interflux Electronics <robot@interflux.com>',
+      reply_to: 'Interflux Electronics <ask@interflux.com>',
+      # provider: :postmark,
+      postmark_stream: 'outbound',
+      postmark_template_alias: "interflux-event-registration-1-#{template_locale}",
+      postmark_template_model: {
+        first_name: first_name,
+        last_name: last_name,
+        event_name: event.name,
+        event_dates: event.start_to_end_date,
+        event_location: event.location
+      },
+      created_by: self
+    )
+
+    log.info '✅ creating internal email'
+
+    EmailAttempt.create!(
+      to: 'Steven Teliszewski <s.teliszewski@interflux.com>',
+      cc: 'Jan Werkhoven <jw@interflux.au>',
+      from: 'Interflux Electronics <robot@interflux.com>',
+      reply_to: 'Interflux Electronics <ask@interflux.com>',
+      # provider: :postmark,
+      postmark_stream: 'outbound',
+      postmark_template_alias: 'interflux-event-registration-2-en',
+      postmark_template_model: {
+        receiver: {
+          first_name: 'Steven'
+        },
+        attendee: {
+          first_name: first_name,
+          last_name: last_name,
+          role: role,
+          company: company,
+          email: email,
+          locale: locale
+        },
+        event: {
+          name: event.name,
+          dates: event.start_to_end_date,
+          location: event.location
+        }
+      },
+      created_by: self
+    )
+  end
 end

--- a/db/migrate/20240415091050_create_email_attempt.rb
+++ b/db/migrate/20240415091050_create_email_attempt.rb
@@ -1,0 +1,29 @@
+class CreateEmailAttempt < ActiveRecord::Migration[6.1]
+  def change
+    create_table :email_attempts, id: :uuid do |t|
+      t.references :created_by, polymorphic: true, type: :uuid
+
+      t.string :from
+      t.string :to
+      t.string :cc
+      t.string :bcc
+      t.string :reply_to
+
+      t.integer :provider
+
+      t.string :postmark_stream
+      t.string :postmark_template_alias
+      t.jsonb :postmark_template_model, default: {}
+
+      # When storing JSONB
+      # https://dev.to/kputra/rails-postgresql-jsonb-part-1-4ibg
+      t.jsonb :response_body, default: {}
+      t.integer :response_status
+      t.boolean :delivered
+
+      t.timestamps
+    end
+
+    add_index :email_attempts, :response_body, using: :gin
+  end
+end

--- a/db/migrate/20240418113914_add_host_to_event_attendee.rb
+++ b/db/migrate/20240418113914_add_host_to_event_attendee.rb
@@ -1,0 +1,5 @@
+class AddHostToEventAttendee < ActiveRecord::Migration[6.1]
+  def change
+    add_column :event_attendees, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -254,6 +254,7 @@ ActiveRecord::Schema.define(version: 2024_04_18_113914) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "locale"
   end
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_07_010227) do
+ActiveRecord::Schema.define(version: 2024_04_18_113914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -212,6 +212,27 @@ ActiveRecord::Schema.define(version: 2024_04_07_010227) do
     t.datetime "updated_at", null: false
     t.string "variations"
     t.boolean "public", default: false
+  end
+
+  create_table "email_attempts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "created_by_type"
+    t.uuid "created_by_id"
+    t.string "from"
+    t.string "to"
+    t.string "cc"
+    t.string "bcc"
+    t.string "reply_to"
+    t.integer "provider"
+    t.string "postmark_stream"
+    t.string "postmark_template_alias"
+    t.jsonb "postmark_template_model", default: {}
+    t.jsonb "response_body", default: {}
+    t.integer "response_status"
+    t.boolean "delivered"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_by_type", "created_by_id"], name: "index_email_attempts_on_created_by"
+    t.index ["response_body"], name: "index_email_attempts_on_response_body", using: :gin
   end
 
   create_table "employees", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/postmark/api.rb
+++ b/lib/postmark/api.rb
@@ -1,0 +1,128 @@
+module Postmark
+  class Api
+    def initialize(server_token: nil, account_token: nil)
+      @server_token = server_token
+      @account_token = account_token
+    end
+
+    def list_templates
+      done = false # keep fetching until true
+      size = 100 # how many records to fetch per request
+      offset = 0 # where the next record should start
+      count = 1 # request count
+      results = [] # all the templates fetched
+
+      until done
+        response = api.get('/templates') do |req|
+          req.params = {
+            count: size,
+            offset: offset
+          }.compact
+        end
+
+        raise "#{response.status} #{JSON.parse(response.body)}" if response.status != 200
+
+        first = ((count - 1) * size) + 1
+        last = count * size
+        log.info "✅ request #{first}-#{last}"
+
+        body = JSON.parse(response.body)
+        results.push body['Templates']
+        offset = count * size
+        done = offset > body['TotalCount']
+        count += 1
+      end
+
+      # We have an array of arrays at this point.
+      # First flatten, then return.
+      results.flatten
+    end
+
+    # Send email with template
+    # https://postmarkapp.com/developer/api/templates-api
+    def send_email_with_template(
+      template_model:,
+      from:,
+      to:,
+      template_id: nil,
+      template_alias: nil,
+      inline_css: nil,
+      cc: nil,
+      bcc: nil,
+      tag: nil,
+      reply_to: nil,
+      headers: nil,
+      track_opens: nil,
+      track_links: nil,
+      attachments: nil,
+      metadata: nil,
+      message_stream: nil
+    )
+      # Either the template ID or alias should be passed in
+      # Prefer aliases for readability.
+      # Though IDs cannot change over time, aliases can.
+      raise '🔥 no template' if template_id.nil? && template_alias.nil?
+
+      body = {
+        TemplateId: template_id,
+        TemplateAlias: template_alias,
+        TemplateModel: template_model,
+        InlineCss: inline_css,
+        From: from,
+        To: to,
+        Cc: cc,
+        Bcc: bcc,
+        Tag: tag,
+        ReplyTo: reply_to,
+        Headers: headers,
+        TrackOpens: track_opens,
+        TrackLinks: track_links,
+        Attachments: attachments,
+        Metadata: metadata,
+        MessageStream: message_stream
+      }.compact.to_json
+
+      api.post('/email/withTemplate/') do |req|
+        req.body = body
+      end
+    end
+
+    private
+
+    def api
+      Faraday.new(
+        url: 'https://api.postmarkapp.com',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-Postmark-Server-Token': @server_token,
+          'User-Agent': 'Jan Werkhoven (jw@interflux.au)'
+        }
+      ) do |f|
+        f.request :url_encoded
+        f.request :curl, log, :info
+        f.adapter Faraday.default_adapter
+      end
+    end
+
+    # All endpoints return in the same way.
+    # Raise unless status is 200.
+    # Parse JSON data if present.
+    # Otherwise return nil.
+    # def data
+    #   if @response.status != 200
+    #     ap @body
+    #     ap @response
+    #     raise "🔥 #{@response.status} #{@response.body}"
+    #   end
+
+    #   return JSON.parse(@response.body) if @response.body.present?
+
+    #   nil
+    # end
+
+    def log
+      Rails.logger
+    end
+  end
+end


### PR DESCRIPTION
This PR:

* Adds agnostic portable API wrapper to send emails using Postmark. 💌
* Hooks up the `after_save` of `EventAttendee` to `:send_email`. 📬
* Make the email templates language aware. 🌍
* Adds the gem `faraday_curl` for printing `Faraday` requests as `curl`. 🌊