### PR TITLE
Add migration and serializers for Event.website

### DIFF
--- a/app/controllers/v1/admin/events_controller.rb
+++ b/app/controllers/v1/admin/events_controller.rb
@@ -47,6 +47,7 @@ module V1
           confirmation_email_subject
           confirmation_email_body
           confirmation_email_bcc
+          website
         ]
       end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,6 +17,7 @@
 #  has_registration_form      :boolean
 #  name                       :string
 #  start_date                 :string
+#  website                    :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  country_id                 :string

--- a/app/serializers/v1/admin/event_serializer.rb
+++ b/app/serializers/v1/admin/event_serializer.rb
@@ -14,7 +14,8 @@ module V1
                  :ask_company,
                  :confirmation_email_subject,
                  :confirmation_email_body,
-                 :confirmation_email_bcc
+                 :confirmation_email_bcc,
+                 :website
 
       belongs_to :country
 

--- a/app/serializers/v1/public/event_serializer.rb
+++ b/app/serializers/v1/public/event_serializer.rb
@@ -11,7 +11,8 @@ module V1
                  :ask_first_name,
                  :ask_last_name,
                  :ask_role,
-                 :ask_company
+                 :ask_company,
+                 :website
 
       belongs_to :country
     end

--- a/db/migrate/20240419091308_add_website_to_event.rb
+++ b/db/migrate/20240419091308_add_website_to_event.rb
@@ -1,0 +1,5 @@
+class AddWebsiteToEvent < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_18_113914) do
+ActiveRecord::Schema.define(version: 2024_04_19_091308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define(version: 2024_04_18_113914) do
     t.string "confirmation_email_subject", default: "See you soon at {event_name}!"
     t.string "confirmation_email_body", default: "Hello {first_name} {last_name},    We look forward seeing you at {event_name} on {event_date} in {event_location}.    Best regards,    The Interflux Electronics team"
     t.string "confirmation_email_bcc", default: "s.teliszewski@interflux.com, jw@interflux.au"
+    t.string "website"
   end
 
   create_table "features", primary_key: "slug", id: :string, force: :cascade do |t|

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -17,6 +17,7 @@
 #  has_registration_form      :boolean
 #  name                       :string
 #  start_date                 :string
+#  website                    :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  country_id                 :string


### PR DESCRIPTION
This PR:

* Adds migration and serialisers for extending `Events` with `.website`.

![CleanShot 2024-04-19 at 19 52 28](https://github.com/interflux-electronics/interflux-api-rails-backend/assets/4415419/9e168c5a-a462-4113-9f5f-61d8e83225e3)
