### PR TITLE
Release 🐝

### DIFF
--- a/app/controllers/concerns/json_api_controller.rb
+++ b/app/controllers/concerns/json_api_controller.rb
@@ -274,6 +274,7 @@ module JsonApiController
 
   # To avoid N+1 we include all the includes.
   def model_class_with_includes
+    return model_class if params[:include].blank?
     return model_class unless strong_includes
 
     list = []

--- a/app/controllers/concerns/json_api_controller.rb
+++ b/app/controllers/concerns/json_api_controller.rb
@@ -146,7 +146,11 @@ module JsonApiController
     return error_forbidden_filters if forbidden_filters.any?
 
     # First we gather all records of the model class.
-    records = model_class_with_includes.all
+    records = if @records.nil?
+                params[:include].present? ? model_class_with_includes.all : model_class.all
+              else
+                @records # set in the controller, prevents .all
+              end
 
     # Next we reduce this collection with the permanent and requested filters.
     #
@@ -183,7 +187,7 @@ module JsonApiController
     options[:include] = strong_includes if strong_includes
 
     # We create a JSON response from the records we collected using the fast and
-    # JSON API compliant Netflux serializers.
+    # JSON API compliant Netflix serializers.
     json = serializer_class.new(records, options).serializable_hash.to_json
 
     # Finally we return the JSON with a 200.

--- a/app/controllers/concerns/json_api_controller.rb
+++ b/app/controllers/concerns/json_api_controller.rb
@@ -288,7 +288,7 @@ module JsonApiController
         value = split[1]
         hash = {}
         hash[key] = value
-        # list.push(**hash)
+        list.push(**hash)
       else
         list.push(symbol)
       end

--- a/app/controllers/v1/public/company_markets_controller.rb
+++ b/app/controllers/v1/public/company_markets_controller.rb
@@ -30,6 +30,19 @@ module V1
       def serializer_class
         V1::Public::CompanyMarketSerializer
       end
+
+      def permitted_includes
+        %i[
+          company
+          country
+        ]
+      end
+
+      def permitted_filters
+        %i[
+          country
+        ]
+      end
     end
   end
 end

--- a/app/controllers/v1/public/events_controller.rb
+++ b/app/controllers/v1/public/events_controller.rb
@@ -2,6 +2,9 @@ module V1
   module Public
     class EventsController < V1::PublicController
       def index
+        @records = Event.upcoming if params['upcoming'] == 'true'
+        @records = Event.past if params['past'] == 'true'
+
         allow_index
       end
 
@@ -34,6 +37,13 @@ module V1
       def permitted_includes
         %i[
           country
+        ]
+      end
+
+      def permitted_filters
+        %i[
+          upcoming
+          past
         ]
       end
     end

--- a/app/controllers/v1/public_controller.rb
+++ b/app/controllers/v1/public_controller.rb
@@ -1,4 +1,5 @@
 module V1
   class PublicController < ApplicationController
+    # TODO: add permanent filter public=true
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,13 +34,13 @@ class Event < ApplicationRecord
     "#{city}, #{country.name_english}"
   end
 
+  scope :past, -> { where('start_date < ?', Date.current - 2.days) }
+  scope :upcoming, -> { where('start_date >= ?', Date.current - 2.days) }
+
   def start_to_end_date
     return '?' if sd.nil? && ed.nil?
-
     return sd.strftime('%a %-d %b %Y') if sd.present? && ed.nil?
-
     return sd.strftime('%a %-d %b %Y') if ed == sd
-
     return "#{sd.strftime('%a %d')} to #{ed.strftime('%a %-d %b %Y')}" if sd.month == ed.month
 
     "#{sd.strftime('%a %-d %b %Y')} to #{ed.strftime('%a %-d %b %Y')}"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   end
 
   # Return a 404 to all requests who are not these hosts:
-  config.hosts = ["localhost", "127.0.0.1"]
+  config.hosts = ['localhost', '127.0.0.1']
 
   # Configure CORS.
   # Note that the Interflux front-end live on different domains than their backend.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,13 @@ Rails.application.configure do
     Bullet.console       = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
+
+    # Disable only the "AVOID eager loading" warnings
+    Bullet.unused_eager_loading_enable = false
+
+    # Keep other useful warnings
+    Bullet.n_plus_one_query_enable = true
+    Bullet.counter_cache_enable = true
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -20,7 +20,7 @@ echo "✅ Downloaded production database"
 echo "----------"
 ls -la db/dumps
 echo "----------"
-RAILS_ENV=development rails db:drop db:create
+RAILS_ENV=development DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop db:create
 echo "----------"
 echo "✅ Reset local database"
 echo "----------"


### PR DESCRIPTION
New in the Interflux API

* Controllers can now pass `@records` into JSON API logic to avoid `Foo.all`
* `Event` can now be filtered by past or upcoming
*  Ignore Bullet's eager include warnings because inaccurate
* Allow `CompanyMarket` to be filtered by country
* Skip the DB ENV check in DEV since we now use SQL dumps instead of YML extracts as database backups